### PR TITLE
Fix wallet connect issue

### DIFF
--- a/src/components/Modals/WalletConnect/index.tsx
+++ b/src/components/Modals/WalletConnect/index.tsx
@@ -14,11 +14,11 @@ import {
   useInkathon,
 } from '@scio-labs/use-inkathon';
 import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
 import { useCoretimeApi, useRelayApi } from '@/contexts/apis';
 
 import styles from './index.module.scss';
-import { useEffect, useState } from 'react';
 
 interface WalletModalProps {
   open: boolean;

--- a/src/components/Modals/WalletConnect/index.tsx
+++ b/src/components/Modals/WalletConnect/index.tsx
@@ -18,6 +18,7 @@ import Image from 'next/image';
 import { useCoretimeApi, useRelayApi } from '@/contexts/apis';
 
 import styles from './index.module.scss';
+import { useEffect, useState } from 'react';
 
 interface WalletModalProps {
   open: boolean;
@@ -25,16 +26,27 @@ interface WalletModalProps {
 }
 
 export const WalletModal = (props: WalletModalProps) => {
-  const { connect: connectContract, activeChain } = useInkathon();
+  const { connect: connectContract, activeChain, isConnected } = useInkathon();
   const { connectRelay } = useRelayApi();
   const { connectCoretime } = useCoretimeApi();
+
+  const [wallet, setWallet] = useState<SubstrateWallet | null>(null);
+
   const onConnect = async (wallet: SubstrateWallet) => {
+    setWallet(wallet);
     if (!connectContract) return;
     connectRelay();
     connectCoretime();
     connectContract(activeChain, wallet);
     props.onClose();
   };
+
+  useEffect(() => {
+    if (wallet) {
+      onConnect(wallet);
+    }
+  }, [isConnected]);
+
   return (
     <Dialog {...props} fullWidth maxWidth='sm'>
       <DialogTitle>Choose your wallet extension</DialogTitle>


### PR DESCRIPTION
Sometimes when clicking on the 'Connect wallet' button the account doesn't get selected.

This is because the `connect` function from `useInkathon` isn't available at the moment of calling. This resolves the problem.