### PR TITLE
Fix subscan url

### DIFF
--- a/src/components/Tables/ParachainTable/index.tsx
+++ b/src/components/Tables/ParachainTable/index.tsx
@@ -23,7 +23,7 @@ import React, { useEffect, useState } from 'react';
 
 import { Link } from '@/components/Elements';
 
-import { SUBSCAN_URL } from '@/consts';
+import { SUSBCAN_RELAY_URL } from '@/consts';
 import { useRelayApi } from '@/contexts/apis';
 import { useNetwork } from '@/contexts/network';
 import { ParachainInfo, ParaState } from '@/models';
@@ -152,14 +152,14 @@ export const ParachainTable = ({
         <TableBody>
           {(rowsPerPage > 0
             ? parachains.slice(
-                page * rowsPerPage,
-                page * rowsPerPage + rowsPerPage
-              )
+              page * rowsPerPage,
+              page * rowsPerPage + rowsPerPage
+            )
             : parachains
           ).map(({ id, name, state, watching, logo, homepage }, index) => (
             <StyledTableRow key={index}>
               <StyledTableCell style={{ width: '10%' }}>
-                <Link href={`${SUBSCAN_URL[network]}/parachain/${id}`}>
+                <Link href={`${SUSBCAN_RELAY_URL[network]}/parachain/${id}`}>
                   {id}
                 </Link>
               </StyledTableCell>

--- a/src/components/Tables/PurchaseHistoryTable/index.tsx
+++ b/src/components/Tables/PurchaseHistoryTable/index.tsx
@@ -17,7 +17,7 @@ import { getBalanceString } from '@/utils/functions';
 
 import { Address, Link } from '@/components/Elements';
 
-import { SUBSCAN_URL } from '@/consts';
+import { SUSBCAN_CORETIME_URL } from '@/consts';
 import { useCoretimeApi } from '@/contexts/apis';
 import { useNetwork } from '@/contexts/network';
 import { PurchaseHistoryItem } from '@/models';
@@ -79,7 +79,7 @@ export const PurchaseHistoryTable = ({ data }: PurchaseHistoryTableProps) => {
                 <StyledTableRow key={index}>
                   <StyledTableCell align='center'>
                     <Link
-                      href={`${SUBSCAN_URL[network]}/extrinsic/${extrinsic_index}`}
+                      href={`${SUSBCAN_CORETIME_URL[network]}/extrinsic/${extrinsic_index}`}
                       target='_blank'
                     >
                       {extrinsic_index}
@@ -87,7 +87,7 @@ export const PurchaseHistoryTable = ({ data }: PurchaseHistoryTableProps) => {
                   </StyledTableCell>
                   <StyledTableCell align='center'>
                     <Link
-                      href={`${SUBSCAN_URL[network]}/account/${address}`}
+                      href={`${SUSBCAN_CORETIME_URL[network]}/account/${address}`}
                       target='_blank'
                     >
                       <Address

--- a/src/consts/index.ts
+++ b/src/consts/index.ts
@@ -8,9 +8,15 @@ export const SUBSCAN_CORETIME_API = {
   [NetworkType.NONE]: '',
 };
 
-export const SUBSCAN_URL = {
+export const SUSBCAN_CORETIME_URL = {
   [NetworkType.ROCOCO]: 'https://coretime-rococo.subscan.io',
   [NetworkType.KUSAMA]: 'https://coretime-kusama.subscan.io',
+  [NetworkType.NONE]: '',
+};
+
+export const SUSBCAN_RELAY_URL = {
+  [NetworkType.ROCOCO]: 'https://rococo.subscan.io',
+  [NetworkType.KUSAMA]: 'https://kusama.subscan.io',
   [NetworkType.NONE]: '',
 };
 


### PR DESCRIPTION
We used the URL pointing to the Coretime chain when we should have pointed to the relay chain.

This PR fixes that and makes the naming more explicit.