### PR TITLE
Cores on sale fix

### DIFF
--- a/src/contexts/sales/index.tsx
+++ b/src/contexts/sales/index.tsx
@@ -131,6 +131,7 @@ const SaleInfoProvider = ({ children }: Props) => {
       const saleInfoRaw = await coretimeApi.query.broker.saleInfo();
       const saleInfo = saleInfoRaw.toJSON() as SaleInfo;
       saleInfo.price = saleInfo.selloutPrice || 0;
+      saleInfo.coresOffered = saleInfo.coresOffered - saleInfo.firstCore;
       setSaleInfo(saleInfo);
 
       const configRaw = await coretimeApi.query.broker.configuration();

--- a/src/contexts/sales/index.tsx
+++ b/src/contexts/sales/index.tsx
@@ -132,6 +132,7 @@ const SaleInfoProvider = ({ children }: Props) => {
       const saleInfo = saleInfoRaw.toJSON() as SaleInfo;
       saleInfo.price = saleInfo.selloutPrice || 0;
       saleInfo.coresOffered = saleInfo.coresOffered - saleInfo.firstCore;
+      saleInfo.idealCoresSold = saleInfo.idealCoresSold - saleInfo.firstCore;
       setSaleInfo(saleInfo);
 
       const configRaw = await coretimeApi.query.broker.configuration();


### PR DESCRIPTION
Cores offered doesn't equal to cores on sale. This is because a some cores are reserved by leases and system parachains. The actual number of cores offered on sale is `coresOffered - firstCore`.